### PR TITLE
Getting the statsd-ganglia-backend to work with the new node-gmetrics library

### DIFF
--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -31,20 +31,36 @@ var gangliaStats = {};
 
 var post_stats = function ganglia_post_stats(rstats) {
   if (gangliaHost) {
-    if (typeof gmetric == 'undefined') {
-      if (debug) {
-        util.log('Initializing gmetric with ' + gangliaHost + ':' + gangliaPort);
-      }
-      gmetric = new gm.gmetric( gangliaHost, gangliaPort, gangliaSpoof != null ? gangliaSpoof : null );
-    }
+    // if (typeof gmetric == 'undefined') {
+    //   if (debug) {
+    //     util.log('Initializing gmetric with ' + gangliaHost + ':' + gangliaPort);
+    //   }
+    //   gmetric = new gm( gangliaHost, gangliaPort, gangliaSpoof != null ? gangliaSpoof : null );
+    // }
 
     for (var k in rstats) {
       if (rstats.hasOwnProperty(k)) {
         try {
           if (debug) {
-            util.log('gmetric.sendMetric ' + k + ' ' + rstats[k]);
+            util.log('gmetric.send ' + k + ' ' + rstats[k]);
           }
-          gmetric.sendMetric( gangliaUseHost, k, rstats[k], 'count', gm.VALUE_INT, gm.SLOPE_BOTH, 0, 0, 'stats' );
+          //gmetric.send( gangliaUseHost, k, rstats[k], 'count', gm.VALUE_INT, gm.SLOPE_BOTH, 0, 0, 'stats' );
+
+          var gmetric = new Gmetric();
+          var metric = {
+            hostname: (gangliaSpoof != null) ? gangliaUseHost : gangliaSpoof,
+            group: gangliaGroup,
+            spoof: (gangliaSpoof != null),
+            units: 'count',
+            slope: 'both',
+
+            name: k,
+            value: rstats[k],
+            type: 'int32'
+          };
+
+          gmetric.send(gangliaHost, gangliaPort, metric);
+
           gangliaStats.last_flush = Math.round(new Date().getTime() / 1000);
         } catch (e) {
           if (debug) {
@@ -155,6 +171,7 @@ exports.init = function ganglia_init(startup_time, config, events) {
   gangliaPort = config.ganglia.port || 8649;
   gangliaSpoof = config.ganglia.spoof;
   gangliaUseHost = config.ganglia.useHost;
+  gangliaGroup = config.ganglia.group || 'StatsD';
 
   gangliaStats.last_flush = startup_time;
   gangliaStats.last_exception = startup_time;

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -57,7 +57,7 @@ var post_stats = function ganglia_post_stats(rstats) {
 
             name: k,
             value: rstats[k],
-            type: 'int32'
+            type: 'int32',
             tmax: 0,
             dmax: 0
           };

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -13,6 +13,7 @@
  *   port:    Port to contact ganglia gmond server at.
  *   spoof:   Ganglia "spoof" string.
  *   useHost: Present as this hostname to gmond
+ *   group:   The gmond group
  *
  */
 
@@ -50,13 +51,15 @@ var post_stats = function ganglia_post_stats(rstats) {
           var metric = {
             hostname: (gangliaSpoof != null) ? gangliaUseHost : gangliaSpoof,
             group: gangliaGroup,
-            spoof: (gangliaSpoof != null),
+            spoof: (gangliaSpoof != null) ? 0 : 1,
             units: 'count',
             slope: 'both',
 
             name: k,
             value: rstats[k],
             type: 'int32'
+            tmax: 0,
+            dmax: 0
           };
 
           gmetric.send(gangliaHost, gangliaPort, metric);

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -18,7 +18,7 @@
 
 var net = require('net'),
    util = require('util'),
-   gm   = require('gmetric');
+   gmetric   = require('gmetric');
 
 var debug;
 var flushInterval;
@@ -46,7 +46,7 @@ var post_stats = function ganglia_post_stats(rstats) {
           }
           //gmetric.send( gangliaUseHost, k, rstats[k], 'count', gm.VALUE_INT, gm.SLOPE_BOTH, 0, 0, 'stats' );
 
-          var gmetric = new Gmetric();
+          var gmetric = new gmetric();
           var metric = {
             hostname: (gangliaSpoof != null) ? gangliaUseHost : gangliaSpoof,
             group: gangliaGroup,

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -51,7 +51,7 @@ var post_stats = function ganglia_post_stats(rstats) {
           var metric = {
             hostname: (gangliaSpoof != null) ? gangliaUseHost : gangliaSpoof,
             group: gangliaGroup,
-            spoof: (gangliaSpoof != null) ? 0 : 1,
+            spoof: (gangliaSpoof != null) ? 1 : 0,
             units: 'count',
             slope: 'both',
 

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -11,9 +11,9 @@
  *
  *   host:    Hostname of ganglia gmond server.
  *   port:    Port to contact ganglia gmond server at.
- *   spoof:   Ganglia "spoof" string.
+ *   spoof:   Ganglia "spoof" string (e.g. "<ip>:<hostname>" or "<hostname>:<hostname>").
  *   useHost: Present as this hostname to gmond
- *   group:   The gmond group
+ *   group:   The group name under which the stats should appear in the ganglia-webfrontend
  *
  */
 
@@ -32,20 +32,12 @@ var gangliaStats = {};
 
 var post_stats = function ganglia_post_stats(rstats) {
   if (gangliaHost) {
-    // if (typeof gmetric == 'undefined') {
-    //   if (debug) {
-    //     util.log('Initializing gmetric with ' + gangliaHost + ':' + gangliaPort);
-    //   }
-    //   gmetric = new gm( gangliaHost, gangliaPort, gangliaSpoof != null ? gangliaSpoof : null );
-    // }
-
     for (var k in rstats) {
       if (rstats.hasOwnProperty(k)) {
         try {
           if (debug) {
             util.log('gmetric.send ' + k + ' ' + rstats[k]);
           }
-          //gmetric.send( gangliaUseHost, k, rstats[k], 'count', gm.VALUE_INT, gm.SLOPE_BOTH, 0, 0, 'stats' );
 
           var gmetric = new gm();
           var metric = {

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -18,7 +18,7 @@
 
 var net = require('net'),
    util = require('util'),
-   gmetric   = require('gmetric');
+   gm   = require('gmetric');
 
 var debug;
 var flushInterval;
@@ -46,7 +46,7 @@ var post_stats = function ganglia_post_stats(rstats) {
           }
           //gmetric.send( gangliaUseHost, k, rstats[k], 'count', gm.VALUE_INT, gm.SLOPE_BOTH, 0, 0, 'stats' );
 
-          var gmetric = new gmetric();
+          var gmetric = new gm();
           var metric = {
             hostname: (gangliaSpoof != null) ? gangliaUseHost : gangliaSpoof,
             group: gangliaGroup,

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -49,9 +49,9 @@ var post_stats = function ganglia_post_stats(rstats) {
 
           var gmetric = new gm();
           var metric = {
-            hostname: (gangliaSpoof != null) ? gangliaUseHost : gangliaSpoof,
+            hostname: (gangliaSpoof != null) ? gangliaSpoof : gangliaUseHost,
             group: gangliaGroup,
-            spoof: (gangliaSpoof != null) ? 1 : 0,
+            spoof: (gangliaSpoof != null),
             units: 'count',
             slope: 'both',
 


### PR DESCRIPTION
Hi,

I wanted to use your StatsD Ganglia backend but it kept crashing the StatsD server.

I discovered that the backend was using an old version of node-gmetrics. So I updated it to be compatible with the node-gmetrics version available via npm.

Greets
