### PR TITLE
Add stats-meta-data mappers

### DIFF
--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -144,6 +144,10 @@ var post_stats = function ganglia_post_stats(rstats) {
 
           if (rstats[k] != null && !isNaN(rstats[k])) {
             gmetric.send(gangliaHost, gangliaPort, metric);
+          } else {
+            if (debug) {
+              util.log('Metric ' + k + ' has an unknown value: ' + rstats[k])
+            }
           }
 
           gangliaStats.last_flush = Math.round(new Date().getTime() / 1000);
@@ -251,7 +255,7 @@ var backend_status = function ganglia_status(writeCb) {
 };
 
 exports.init = function ganglia_init(startup_time, config, events) {
-  debug = config.debug;
+  debug = config.debug && config.ganglia.debug;
   gangliaHost = config.ganglia.host;
   gangliaPort = config.ganglia.port || 8649;
   gangliaSpoof = config.ganglia.spoof;


### PR DESCRIPTION
Hi,

I've had the desire to be able to rename my metrics dynamically (and also change the group they're put into).

So I've implemented a middleware for the plugin which lets you write a JavaScript method which maps the metric's meta data to another one.

Also I've introduced a switch which enables/disables the debugging output of the Ganglia plugin so you can switch debugging on but disable the Ganglia plugin debugging output.

Real used example config (statsd_config.js):

``` javascript
....
, ganglia: {
    host: 'xxx.xxx.nu',
    port: 8650,
    useHost: 'statsd',
    spoof: 'StatsD:StatsD',
    group: 'StatsD',
    debug: false,
    mappings: {
      ALL: {
        mappingMethod: 'mapMetric',
        mappingSource: './ganglia_mapper'
      }
    }
  }
```

./backends/ganglia_mapper.js:

``` javascript
exports.mapMetric = function (metric) {
  // Remove the first part of the metric path and change the units & group
  if (metric.name.indexOf('stats_counts_myproject.') != -1 || metric.name.indexOf('stats_myproject.') != -1) {
    metric.name = metric.name.replace('stats_counts_myproject.', '')
    metric.name = metric.name.replace('stats_myproject.', '')
    metric.group = 'myproject'
  } else if (metric.name.indexOf('stats_timers_myproject.') != -1) {
    metric.name = metric.name.replace('stats_timers_myproject.', '')
    metric.units = 'milliseconds'
    metric.group = 'myproject'
  } else if (metric.name.indexOf('stats_gauges_myproject.') != -1) {
    metric.name = metric.name.replace('stats_gauges_myproject.', '')
    metric.units = 'gauge'
    metric.type = 'float'
    metric.group = 'myproject'
  }

  // Remove eventually leftover first parts of the metric path
  metric.name = metric.name.replace('stats_myproject.', '')

  if (metric.name.indexOf('statsd') == -1) {
    // Generate a new metric group based on the metric path
    var nameParts = metric.name.split('.')
    if (nameParts != null && nameParts.length > 0) {
      metric.group = metric.group + " - " + nameParts[0] + ":" + nameParts[1]
    }
  }

  return metric
}
```
