### PR TITLE
Update dependency version for Gmetric

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "version": "0.2.1",
   "dependencies": {
-    "gmetric": "0.0.4"
+    "gmetric": "0.2.2"
   },
   "devDependencies": {
     "nodeunit": "0.7.x"


### PR DESCRIPTION
When running this backend with the current dependencies, I got the following exception:

Exception: TypeError: object is not a function, at line 130 (var gmetric = new gm();)

Updating to gmetric to 0.2.2  solves this problem.
