### PR TITLE
Finish catching up with current gmetric calling convention. issue #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ cd /usr/local/lib/node_modules/statsd
 npm install statsd-ganglia-backend
 ```
 
+Note that this backend does not have multicast support. You must 
+configure a non-multicast UDP listener in your gmond.conf:
+
+```
+/* Plain old UDP, no mcast. */
+udp_recv_channel { 
+  port = 8650
+} 
+```
+
+and configure this backend to send messages to that port.
+
+
 ## License
 
 ```

--- a/statsd-ganglia-backend/index.js
+++ b/statsd-ganglia-backend/index.js
@@ -63,7 +63,7 @@
 
 var net = require('net'),
    util = require('util'),
-   gm   = require('gmetric');
+   Gmetric   = require('gmetric');
 
 var debug;
 var flushInterval;


### PR DESCRIPTION
The 'var' at the top also needs to be named Gmetric. This version seems to work for me.
